### PR TITLE
YSMOD-403

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<token-support.version>1.3.8</token-support.version>
 		<openapi-generator.version>5.3.0</openapi-generator.version>
 		<springdoc-openapi-ui.version>1.6.5</springdoc-openapi-ui.version>
-		<yrkesskade-felles-backend.version>8be18167_202205131925</yrkesskade-felles-backend.version>
+		<yrkesskade-felles-backend.version>7d147e18_202206141156</yrkesskade-felles-backend.version>
 	</properties>
 
 	<repositories>
@@ -307,6 +307,51 @@
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.8</version>
+				<configuration>
+					<excludes>
+						<exclude>no.nav.yrkesskade.ysmeldingapi.mockserver</exclude>
+						<exclude>no.nav.yrkesskade.ysmeldingapi/**/*Exception.*</exclude>
+					</excludes>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<rule>
+									<element>BUNDLE</element>
+									<limits>
+										<limit>
+											<counter>INSTRUCTION</counter>
+											<value>COVEREDRATIO</value>
+											<minimum>0.71</minimum>
+										</limit>
+									</limits>
+								</rule>
+							</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/mockserver/AbstractMockServer.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/mockserver/AbstractMockServer.kt
@@ -169,7 +169,7 @@ open class AbstractMockSever(private val port: Int?) {
             }
         }
 
-        val kodeverkUtenKategorier = listOf<String>("fravaertype", "landkoderISO2", "rolletype")
+        val kodeverkUtenKategorier = listOf<String>("fravaertype", "landkoderISO2", "rolletype", "sykdomstype", "paavirkningsform")
         kodeverkUtenKategorier.forEach {
             log.info("Wiremock stub $it til -> mock/kodeverk/$it.json")
             stubForGet(urlPathMatching("/api/v1/kodeverk/typer/$it/kodeverdier")) {

--- a/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/models/Skjematype.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/models/Skjematype.kt
@@ -1,0 +1,17 @@
+package no.nav.yrkesskade.ysmeldingapi.models
+
+enum class Skjematype(
+    val rolletype: String,
+    val harStilling: Boolean = false,
+    val harStedsbeskrivelse: Boolean = false
+    ) {
+    ARBEIDSTAKER("arbeidstaker", harStedsbeskrivelse = true, harStilling = true),
+    LAERLING("laerling", harStedsbeskrivelse = true, harStilling = true),
+    ELEV_ELLER_STUDENT("elevEllerStudent"),
+    TILTAKSDELTAKER("tiltaksdeltaker");
+
+    companion object {
+        private val map = Skjematype.values().associateBy(Skjematype::rolletype)
+        fun hentSkjematypeForNavn(navn: String): Skjematype? = map[navn]
+    }
+}

--- a/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/services/SkademeldingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/ysmeldingapi/services/SkademeldingService.kt
@@ -96,7 +96,7 @@ class SkademeldingService(private val skademeldingInnsendingClient: Skademelding
         check(skademelding.innmelder.innmelderrolle == "virksomhetsrepresentant", { "${skademelding.innmelder.innmelderrolle} er ikke en gyldig verdi. Må være virksomhetsrepresentant"})
 
         // Hent kodelister basert på rolletype som skal benyttes for å finne gyldige verdier
-        check(skademelding.skadelidt.dekningsforhold.rolletype != null, { "rolletype er påkrevd" })
+        checkNotNull(skademelding.skadelidt.dekningsforhold.rolletype, { "rolletype er påkrevd" })
 
         val rolletype = skademelding.skadelidt.dekningsforhold.rolletype
 

--- a/src/main/resources/mock/kodeverk/paavirkningsform.json
+++ b/src/main/resources/mock/kodeverk/paavirkningsform.json
@@ -1,0 +1,16 @@
+{
+  "kodeverdierMap": {
+    "kjemikalierEllerLoesemidler": {
+      "kode": "kjemikalierEllerLoesemidler",
+      "verdi": "Kjemikalier, løsemidler, gift, gass, væske o.l."
+    },
+    "stoevpaavirkning": {
+      "kode": "stoevpaavirkning",
+      "verdi": "Støvpåvirkning, stenstøv, asbest o.l."
+    },
+    "stoey": {
+      "kode": "stoey",
+      "verdi": "Støy"
+    }
+  }
+}

--- a/src/main/resources/mock/kodeverk/sykdomstype.json
+++ b/src/main/resources/mock/kodeverk/sykdomstype.json
@@ -1,0 +1,16 @@
+{
+  "kodeverdierMap": {
+    "sykdomIHjernenEllerNervesystemet": {
+      "kode": "sykdomIHjernenEllerNervesystemet",
+      "verdi": "Sykdom i hjernen eller i nervesystemet"
+    },
+    "oeyesykdom": {
+      "kode": "oeyesykdom",
+      "verdi": "Øyesykdom"
+    },
+    "oeresykdom": {
+      "kode": "oeresykdom",
+      "verdi": "Øresykdom"
+    }
+  }
+}

--- a/src/test/kotlin/no/nav/yrkesskade/ysmeldingapi/controllers/SkademeldingApiControllerIT.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/ysmeldingapi/controllers/SkademeldingApiControllerIT.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.yrkesskade.ysmeldingapi.fixtures.enkelSkademelding
 import no.nav.yrkesskade.ysmeldingapi.fixtures.skademeldingMedFeilStillingstittelFormat
 import no.nav.yrkesskade.ysmeldingapi.fixtures.skademeldingMedPeriodeFraDatoSammeSomTilDato
+import no.nav.yrkesskade.ysmeldingapi.fixtures.skademeldingMedPeriodeOgSykdomsinformasjon
 import no.nav.yrkesskade.ysmeldingapi.mockserver.FNR_UTEN_ORGANISASJONER
 import no.nav.yrkesskade.ysmeldingapi.models.SkademeldingDto
 import no.nav.yrkesskade.ysmeldingapi.test.AbstractIT
@@ -74,11 +75,21 @@ class SkademeldingApiControllerIT: AbstractIT() {
     }
 
     @Test
-    fun `valider skademelding med periode tidstype hvor fra dato er samme som til dato`() {
+    fun `valider skademelding med periode tidstype hvor fra dato er samme som til dato - mangler sykdomstype, sykdomPaavist og paavirkningsform`() {
         val jwt = mvc.perform(MockMvcRequestBuilders.get("/local/jwt")).andReturn().response.contentAsString
         assertThat(jwt).isNotNull()
 
         postSkademelding(skademeldingMedPeriodeFraDatoSammeSomTilDato(), jwt)
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().is4xxClientError)
+    }
+
+    @Test
+    fun `valider skademelding med periode tidstype`() {
+        val jwt = mvc.perform(MockMvcRequestBuilders.get("/local/jwt")).andReturn().response.contentAsString
+        assertThat(jwt).isNotNull()
+
+        postSkademelding(skademeldingMedPeriodeOgSykdomsinformasjon(), jwt)
             .andDo(MockMvcResultHandlers.print())
             .andExpect(status().isCreated)
     }

--- a/src/test/kotlin/no/nav/yrkesskade/ysmeldingapi/fixtures/skademeldingDtoFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/ysmeldingapi/fixtures/skademeldingDtoFixtures.kt
@@ -28,6 +28,10 @@ fun skademeldingMedPeriodeFraDatoSammeSomTilDato(): String {
     return Files.readString(Path.of("src/test/resources/skademeldinger/fradatoSammeSomTilDato.json"))
 }
 
+fun skademeldingMedPeriodeOgSykdomsinformasjon(): String {
+    return Files.readString(Path.of("src/test/resources/skademeldinger/yrkessykdom.json"))
+}
+
 fun fullSkademelding(): Skademelding {
     return Skademelding(
         innmelder = arbeidsgiverInnmelder(),

--- a/src/test/resources/skademeldinger/yrkessykdom.json
+++ b/src/test/resources/skademeldinger/yrkessykdom.json
@@ -1,0 +1,53 @@
+{
+  "innmelder": {
+    "norskIdentitetsnummer": "16120101181",
+    "paaVegneAv": "910441205",
+    "innmelderrolle": "virksomhetsrepresentant",
+    "altinnrolleIDer": []
+  },
+  "skadelidt": {
+    "norskIdentitetsnummer": "10117424370",
+    "dekningsforhold": {
+      "stillingstittelTilDenSkadelidte": ["toppledereIOffentligAdministrasjon"],
+      "organisasjonsnummer": "910441205",
+      "navnPaaVirksomheten": "BIRI OG TORPO REGNSKAP",
+      "rolletype": "arbeidstaker"
+    }
+  },
+  "skade": {
+    "alvorlighetsgrad": "antattOppsoektLege",
+    "skadedeDeler": [
+      {
+        "skadeartTabellC": "bloetdelsskadeUtenSaar",
+        "kroppsdelTabellD": "venstreOeye"
+      }
+    ],
+    "antattSykefravaerTabellH": "merEnnTreDager",
+    "sykdomstype": "sykdomIHjernenEllerNervesystemet"
+  },
+  "hendelsesfakta": {
+    "tid": { "tidstype": "Periode",
+      "periode": {
+        "fra": "2020-02-02",
+        "til": "2022-02-02",
+        "sykdomPaavist": "2022-05-01"
+      }
+    },
+    "paavirkningsform": "kjemikalierEllerLoesemidler",
+    "naarSkjeddeUlykken": "fritidEllerPrivatAktivitet",
+    "hvorSkjeddeUlykken": "arbeidsstedInne",
+    "ulykkessted": {
+      "sammeSomVirksomhetensAdresse": true,
+      "adresse": {
+        "adresselinje1": "Testveien 1",
+        "adresselinje2": "1111",
+        "adresselinje3": "TEST",
+        "land": "NO"
+      }
+    },
+    "aarsakUlykkeTabellAogE": ["sammenstoetEllerBittEllerSpark"],
+    "bakgrunnsaarsakTabellBogG": ["verneutstyrFjernet"],
+    "utfyllendeBeskrivelse": "Test",
+    "stedsbeskrivelseTabellF": "idrettsomraade"
+  }
+}


### PR DESCRIPTION
- oppgraderte yrkesskade-backend felles kode til siste i henhold til ny kontrakt
- opprettet skjematype enum for enklere lage dynamisk kode i validering
- satte på code coverage krav på bygging av prosjektet til 71 % dekning
- oppdatert test
- validering av nye felter